### PR TITLE
downgrade ubuntu to G++ 10

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rte-france/or-tools
-          ref: ${{ github.event.inputs.rtefrance_ortools_branch || 'main' }}
+          ref: ${{ github.event.inputs.rtefrance_ortools_branch || 'feature/basis_python' }}
 
       - name: Checkout this repository
         uses: actions/checkout@v4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rte-france/or-tools
-          ref: ${{ github.event.inputs.rtefrance_ortools_branch || 'feature/basis_python' }}
+          ref: ${{ github.event.inputs.rtefrance_ortools_branch || 'main' }}
 
       - name: Checkout this repository
         uses: actions/checkout@v4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -70,8 +70,8 @@ jobs:
         shell: bash
         run:  |
           sudo apt update
-          sudo apt install gcc-11 g++-11
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
+          sudo apt install gcc-10 g++-10
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 110 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
           sudo apt install -yq build-essential lsb-release zlib1g-dev
 
       - name: Swig install

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -66,7 +66,7 @@ jobs:
           cp -r patch/* .
           python patch.py
 
-      - name: Install GCC11 and others
+      - name: Install GCC10 and others
         shell: bash
         run:  |
           sudo apt update


### PR DESCRIPTION
Downgrade GCC and G++ from 11 to 10 to avoid needing glibcxx_3.4.29