### PR TITLE
Xpress python parser update for MathOpt

### DIFF
--- a/ortools/xpress/parse_header_xpress.py
+++ b/ortools/xpress/parse_header_xpress.py
@@ -99,7 +99,9 @@ class XpressHeaderParser(object):
                                    # MIP STATUS
                                    "XPRS_MIPSTATUS", "XPRS_MIP_INFEAS", "XPRS_MIP_OPTIMAL", "XPRS_MIP_UNBOUNDED",
                                    "XPRS_COLS", "XPRS_NODES", "XPRS_MIP_SOLUTION",
-                                   "XPRS_OBJ_MINIMIZE", "XPRS_OBJ_MAXIMIZE", "XPRS_NAMES_ROW", "XPRS_NAMES_COLUMN"}
+                                   "XPRS_OBJ_MINIMIZE", "XPRS_OBJ_MAXIMIZE", "XPRS_NAMES_ROW", "XPRS_NAMES_COLUMN",
+                                   "XPRS_ALG_DUAL", "XPRS_ALG_PRIMAL", "XPRS_ALG_BARRIER",
+                                   "XPRS_SOLSTATUS_NOTFOUND", "XPRS_SOLSTATUS_OPTIMAL", "XPRS_SOLSTATUS_FEASIBLE", "XPRS_SOLSTATUS_INFEASIBLE", "XPRS_SOLSTATUS_UNBOUNDED"}
         self.__missing_required_defines = self.__required_defines
         # These enum will detect control parameters that will all be imported
         self.__doc_section = XprsDocumentSection.OTHER

--- a/ortools/xpress/parse_header_xpress.py
+++ b/ortools/xpress/parse_header_xpress.py
@@ -91,7 +91,7 @@ class XpressHeaderParser(object):
                                    "XPRS_TYPE_DOUBLE", "XPRS_PLUSINFINITY", "XPRS_MINUSINFINITY",
                                    "XPRS_MAXBANNERLENGTH", "XPVERSION",
                                    "XPRS_LPOBJVAL", "XPRS_MIPOBJVAL", "XPRS_BESTBOUND", "XPRS_OBJRHS", "XPRS_OBJSENSE",
-                                   "XPRS_ROWS", "XPRS_SIMPLEXITER", "XPRS_BARITER",
+                                   "XPRS_ROWS", "XPRS_SIMPLEXITER", "XPRS_BARITER", "XPRS_MAXPROBNAMELENGTH",
                                    # LPSTATUS
                                    "XPRS_LPSTATUS", "XPRS_LP_UNSTARTED", "XPRS_LP_OPTIMAL", "XPRS_LP_INFEAS",
                                    "XPRS_LP_CUTOFF", "XPRS_LP_UNFINISHED", "XPRS_LP_UNBOUNDED",
@@ -121,10 +121,10 @@ class XpressHeaderParser(object):
                                      "XPRSwriteprob", "XPRSgetrowtype", "XPRSgetcoltype", "XPRSgetlpsol",
                                      "XPRSgetmipsol", "XPRSchgbounds", "XPRSchgobj", "XPRSchgcoef", "XPRSchgmcoef", "XPRSchgmcoef64",
                                      "XPRSchgrhs", "XPRSchgrhsrange", "XPRSchgrowtype", "XPRSaddcbmessage",
-                                     "XPRSsetcbmessage",
+                                     "XPRSsetcbmessage", "XPRSsetprobname",
                                      "XPRSaddmipsol", "XPRSaddcbintsol", "XPRSremovecbintsol",
                                      "XPRSinterrupt", "XPRSlpoptimize", "XPRSmipoptimize", "XPRSoptimize", "XPRSsetindicators",
-                                     "XPRSgetcontrolinfo", "XPRSgetsolution", "XPRSgetduals", "XPRSgetredcosts", "XPRSchgmqobj"}
+                                     "XPRSgetcontrolinfo", "XPRSgetduals", "XPRSgetredcosts", "XPRSchgmqobj"}
         self.__missing_required_functions = self.__required_functions
         self.__XPRSprob_section = False
 

--- a/ortools/xpress/parse_header_xpress.py
+++ b/ortools/xpress/parse_header_xpress.py
@@ -117,12 +117,12 @@ class XpressHeaderParser(object):
                                      "XPRSchgcoltype", "XPRSloadbasis",
                                      "XPRSpostsolve", "XPRSchgobjsense", "XPRSgetlasterror", "XPRSgetbasis",
                                      "XPRSwriteprob", "XPRSgetrowtype", "XPRSgetcoltype", "XPRSgetlpsol",
-                                     "XPRSgetmipsol", "XPRSchgbounds", "XPRSchgobj", "XPRSchgcoef", "XPRSchgmcoef",
+                                     "XPRSgetmipsol", "XPRSchgbounds", "XPRSchgobj", "XPRSchgcoef", "XPRSchgmcoef", "XPRSchgmcoef64",
                                      "XPRSchgrhs", "XPRSchgrhsrange", "XPRSchgrowtype", "XPRSaddcbmessage",
                                      "XPRSsetcbmessage",
                                      "XPRSaddmipsol", "XPRSaddcbintsol", "XPRSremovecbintsol",
-                                     "XPRSinterrupt", "XPRSlpoptimize", "XPRSmipoptimize", "XPRSsetindicators",
-                                     "XPRSgetcontrolinfo"}
+                                     "XPRSinterrupt", "XPRSlpoptimize", "XPRSmipoptimize", "XPRSoptimize", "XPRSsetindicators",
+                                     "XPRSgetcontrolinfo", "XPRSgetsolution", "XPRSgetduals", "XPRSgetredcosts", "XPRSchgmqobj"}
         self.__missing_required_functions = self.__required_functions
         self.__XPRSprob_section = False
 

--- a/ortools/xpress/parse_header_xpress.py
+++ b/ortools/xpress/parse_header_xpress.py
@@ -91,7 +91,7 @@ class XpressHeaderParser(object):
                                    "XPRS_TYPE_DOUBLE", "XPRS_PLUSINFINITY", "XPRS_MINUSINFINITY",
                                    "XPRS_MAXBANNERLENGTH", "XPVERSION",
                                    "XPRS_LPOBJVAL", "XPRS_MIPOBJVAL", "XPRS_BESTBOUND", "XPRS_OBJRHS", "XPRS_OBJSENSE",
-                                   "XPRS_ROWS", "XPRS_SIMPLEXITER",
+                                   "XPRS_ROWS", "XPRS_SIMPLEXITER", "XPRS_BARITER",
                                    # LPSTATUS
                                    "XPRS_LPSTATUS", "XPRS_LP_UNSTARTED", "XPRS_LP_OPTIMAL", "XPRS_LP_INFEAS",
                                    "XPRS_LP_CUTOFF", "XPRS_LP_UNFINISHED", "XPRS_LP_UNBOUNDED",

--- a/ortools/xpress/parse_header_xpress.py
+++ b/ortools/xpress/parse_header_xpress.py
@@ -91,7 +91,7 @@ class XpressHeaderParser(object):
                                    "XPRS_TYPE_DOUBLE", "XPRS_PLUSINFINITY", "XPRS_MINUSINFINITY",
                                    "XPRS_MAXBANNERLENGTH", "XPVERSION",
                                    "XPRS_LPOBJVAL", "XPRS_MIPOBJVAL", "XPRS_BESTBOUND", "XPRS_OBJRHS", "XPRS_OBJSENSE",
-                                   "XPRS_ROWS", "XPRS_SIMPLEXITER", "XPRS_BARITER",
+                                   "XPRS_ROWS", "XPRS_SIMPLEXITER", "XPRS_BARITER", "XPRS_LPITERLIMIT", "XPRS_BARITERLIMIT",
                                    # LPSTATUS
                                    "XPRS_LPSTATUS", "XPRS_LP_UNSTARTED", "XPRS_LP_OPTIMAL", "XPRS_LP_INFEAS",
                                    "XPRS_LP_CUTOFF", "XPRS_LP_UNFINISHED", "XPRS_LP_UNBOUNDED",

--- a/ortools/xpress/parse_header_xpress.py
+++ b/ortools/xpress/parse_header_xpress.py
@@ -91,7 +91,7 @@ class XpressHeaderParser(object):
                                    "XPRS_TYPE_DOUBLE", "XPRS_PLUSINFINITY", "XPRS_MINUSINFINITY",
                                    "XPRS_MAXBANNERLENGTH", "XPVERSION",
                                    "XPRS_LPOBJVAL", "XPRS_MIPOBJVAL", "XPRS_BESTBOUND", "XPRS_OBJRHS", "XPRS_OBJSENSE",
-                                   "XPRS_ROWS", "XPRS_SIMPLEXITER", "XPRS_BARITER", "XPRS_LPITERLIMIT", "XPRS_BARITERLIMIT",
+                                   "XPRS_ROWS", "XPRS_SIMPLEXITER", "XPRS_BARITER",
                                    # LPSTATUS
                                    "XPRS_LPSTATUS", "XPRS_LP_UNSTARTED", "XPRS_LP_OPTIMAL", "XPRS_LP_INFEAS",
                                    "XPRS_LP_CUTOFF", "XPRS_LP_UNFINISHED", "XPRS_LP_UNBOUNDED",


### PR DESCRIPTION
Update the Python parser:
- Add missing function that is already used in MPSolver XPRESS interface (XPRSgetcontrolinfo)
- Add LP status enums (used for the MathOpt interface)
- Deliberatly exclude deprecated defines to force us to update them
- Accept comments in the middle of a "define" line in xprs.h